### PR TITLE
Add LinqKit and use it in repositories

### DIFF
--- a/TransIT.API/EndpointFilters/OnException/DataTableFilterExceptionFilterAttribute.cs
+++ b/TransIT.API/EndpointFilters/OnException/DataTableFilterExceptionFilterAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -10,7 +11,14 @@ namespace TransIT.API.EndpointFilters.OnException
     {
         public Task OnExceptionAsync(ExceptionContext context)
         {
-            context.Result = new BadRequestObjectResult(new DataTableResponseDTO { Error = context.Exception.Message });
+            var responseBody = new DataTableResponseDTO
+            {
+                Error = context.Exception.ToString()
+            };
+            context.Result = new ObjectResult(responseBody)
+            {
+                StatusCode = (int)HttpStatusCode.InternalServerError
+            };
             context.ExceptionHandled = true;
             return Task.CompletedTask;
         }

--- a/TransIT.BLL/DTOs/DataTableRequestDTO.cs
+++ b/TransIT.BLL/DTOs/DataTableRequestDTO.cs
@@ -1,4 +1,8 @@
-﻿namespace TransIT.BLL.DTOs
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TransIT.BLL.DTOs
 {
     public class DataTableRequestDTO
     {
@@ -12,6 +16,15 @@
         public ColumnType[] Columns { get; set; }
         public OrderType[] Order { get; set; }
         public FilterType[] Filters { get; set; }
+
+        public IEnumerable<string> SearchEntries
+        {
+            get
+            {
+                return Search.Value.Split(new[] { ' ', ',', '.' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(x => x.Trim().ToUpperInvariant());
+            }
+        }
 
         public class OrderType
         {

--- a/TransIT.BLL/Services/ImplementedServices/ActionTypeService.cs
+++ b/TransIT.BLL/Services/ImplementedServices/ActionTypeService.cs
@@ -46,10 +46,10 @@ namespace TransIT.BLL.Services.ImplementedServices
         public async Task<IEnumerable<ActionTypeDTO>> SearchAsync(string search)
         {
             var actionTypes = await _unitOfWork.ActionTypeRepository.SearchExpressionAsync(
-           search
-               .Split(new[] { ' ', ',', '.' }, StringSplitOptions.RemoveEmptyEntries)
-               .Select(x => x.Trim().ToUpperInvariant())
-           );
+                search
+                    .Split(new[] { ' ', ',', '.' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(x => x.Trim().ToUpperInvariant())
+            );
 
             return _mapper.Map<IEnumerable<ActionTypeDTO>>(await actionTypes.ToListAsync());
         }

--- a/TransIT.DAL/Models/Entities/User.cs
+++ b/TransIT.DAL/Models/Entities/User.cs
@@ -7,6 +7,8 @@ namespace TransIT.DAL.Models.Entities
 {
     public class User : IdentityUser, IAuditableEntity
     {
+        public const string ActiveTranslated = "активний";
+        public const string NotActiveTranslated = "неактивний";
         public User()
         {
             ActionTypeCreate = new HashSet<ActionType>();

--- a/TransIT.DAL/Repositories/ImplementedRepositories/ActionTypeRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/ActionTypeRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
@@ -14,12 +15,25 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
                : base(context)
         {
         }
-        
-        public override Task<IQueryable<ActionType>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.Name.ToUpperInvariant().Contains(str)))
+
+        public override Task<IQueryable<ActionType>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<ActionType>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                        EF.Functions.Like(entity.Name, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
             );
+        }
 
         protected override IQueryable<ActionType> ComplexEntities => Entities.
            Include(t => t.Create).

--- a/TransIT.DAL/Repositories/ImplementedRepositories/CountryRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/CountryRepository.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using LinqKit;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using TransIT.DAL.Models;
@@ -14,10 +16,23 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
         {
         }
         
-        public override Task<IQueryable<Country>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.Name.ToUpperInvariant().Contains(str)))
+        public override Task<IQueryable<Country>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<Country>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                        EF.Functions.Like(entity.Name, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
             );
+        }
     }
 }

--- a/TransIT.DAL/Repositories/ImplementedRepositories/IssueRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/IssueRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
@@ -21,25 +22,52 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
             issue.Number = previousMax + 1;
 
             return await base.AddAsync(issue);
-        }
+        } 
 
-        public override Task<IQueryable<Issue>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.Summary.ToUpperInvariant().Contains(str)
-                    || entity.Malfunction.Name.ToUpperInvariant().Contains(str)
-                    || entity.Malfunction.MalfunctionSubgroup.Name.ToUpperInvariant().Contains(str)
-                    || entity.Malfunction.MalfunctionSubgroup.MalfunctionGroup.Name.ToUpperInvariant().Contains(str)
-                    || !string.IsNullOrEmpty(entity.State.TransName) && entity.State.TransName.ToUpperInvariant().Contains(str)
-                    || !string.IsNullOrEmpty(entity.Vehicle.Brand) && entity.Vehicle.Brand.ToUpperInvariant().Contains(str)
-                    || !string.IsNullOrEmpty(entity.Vehicle.InventoryId) && entity.Vehicle.InventoryId.ToUpperInvariant().Contains(str)
-                    || !string.IsNullOrEmpty(entity.Vehicle.Model) && entity.Vehicle.Model.ToUpperInvariant().Contains(str)
-                    || !string.IsNullOrEmpty(entity.Vehicle.RegNum) && entity.Vehicle.RegNum.ToUpperInvariant().Contains(str)
-                    || !string.IsNullOrEmpty(entity.Vehicle.Vincode) && entity.Vehicle.Vincode.ToUpperInvariant().Contains(str)
-                    || entity.Date.ToString("yyyy-MM-dd").Contains(str)
-                    || entity.Number.ToString().ToUpperInvariant().Contains(str)))
-                );
-        
+        public override Task<IQueryable<Issue>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<Issue>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+               
+                predicate = predicate.And(entity =>
+                       EF.Functions.Like(entity.Summary, '%' + temp + '%')
+                    || EF.Functions.Like(entity.Malfunction.Name, '%' + temp + '%')
+                    || EF.Functions.Like(entity.Malfunction.MalfunctionSubgroup.Name, '%' + temp + '%')
+                    || EF.Functions.Like(entity.Malfunction.MalfunctionSubgroup.MalfunctionGroup.Name, 
+                         '%' + temp + '%')
+                    || entity.State.TransName != null && entity.State.TransName != string.Empty &&
+                           EF.Functions.Like(entity.State.TransName, '%' + temp + '%')
+                    || entity.Vehicle.Brand != null && entity.Vehicle.Brand != string.Empty &&
+                           EF.Functions.Like(entity.Vehicle.Brand, '%' + temp + '%')
+                    || entity.Vehicle.InventoryId != null && entity.Vehicle.InventoryId != string.Empty &&
+                           EF.Functions.Like(entity.Vehicle.InventoryId, '%' + temp + '%')
+                    || entity.Vehicle.Model != null && entity.Vehicle.Model != string.Empty &&
+                           EF.Functions.Like(entity.Vehicle.Model, '%' + temp + '%')
+                    || entity.Vehicle.RegNum != null && entity.Vehicle.RegNum != string.Empty &&
+                           EF.Functions.Like(entity.Vehicle.RegNum, '%' + temp + '%')
+                    || entity.Vehicle.Vincode != null && entity.Vehicle.Vincode != string.Empty &&
+                           EF.Functions.Like(entity.Vehicle.Vincode, '%' + temp + '%')
+                    );
+                if (int.TryParse(temp, out int parsedInteger))
+                {
+                    predicate = predicate.And(entity =>
+                           entity.Number == parsedInteger
+                        || entity.Date.Year == parsedInteger
+                        || entity.Date.Month == parsedInteger
+                        || entity.Date.Day == parsedInteger
+                    );
+                }
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
+            );
+        }
         protected override IQueryable<Issue> ComplexEntities => Entities
             .Include(i => i.AssignedTo)
             .Include(i => i.Create)

--- a/TransIT.DAL/Repositories/ImplementedRepositories/MalfunctionGroupRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/MalfunctionGroupRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
@@ -15,11 +16,25 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
         {
         }
         
-        public override Task<IQueryable<MalfunctionGroup>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.Name.ToUpperInvariant().Contains(str)))
-                );
+         public override Task<IQueryable<MalfunctionGroup>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<MalfunctionGroup>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                       entity.Name != null && entity.Name != string.Empty &&
+                           EF.Functions.Like(entity.Name, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
+            );
+        }
 
         protected override IQueryable<MalfunctionGroup> ComplexEntities => Entities.
                    Include(t => t.Create).

--- a/TransIT.DAL/Repositories/ImplementedRepositories/MalfunctionRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/MalfunctionRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
@@ -15,11 +16,25 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
         {
         }
         
-        public override Task<IQueryable<Malfunction>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.Name.ToUpperInvariant().Contains(str)))
-                );
+         public override Task<IQueryable<Malfunction>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<Malfunction>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                       entity.Name != null && entity.Name != string.Empty &&
+                           EF.Functions.Like(entity.Name, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
+            );
+        }
 
         protected override IQueryable<Malfunction> ComplexEntities => Entities
                     .Include(m => m.Create)

--- a/TransIT.DAL/Repositories/ImplementedRepositories/PostRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/PostRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
@@ -15,11 +16,25 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
         {
         }
         
-        public override Task<IQueryable<Post>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.Name.ToUpperInvariant().Contains(str)))
-                );
+         public override Task<IQueryable<Post>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<Post>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                       entity.Name != null && entity.Name != string.Empty &&
+                           EF.Functions.Like(entity.Name, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
+            );
+        }
 
         protected override IQueryable<Post> ComplexEntities => Entities
             .Include(p => p.Create)

--- a/TransIT.DAL/Repositories/ImplementedRepositories/StateRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/StateRepository.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
+using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
 using TransIT.DAL.Repositories.InterfacesRepositories;
@@ -14,10 +16,24 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
         {
         }
         
-        public override Task<IQueryable<State>> SearchExpressionAsync(IEnumerable<string> strs) =>
-            Task.FromResult(
-                GetQueryable().Where(entity =>
-                    strs.Any(str => entity.TransName.ToUpperInvariant().Contains(str)))
-                );
+         public override Task<IQueryable<State>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<State>();
+
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                       entity.TransName != null && entity.TransName != string.Empty &&
+                           EF.Functions.Like(entity.TransName, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
+            );
+        }
     }
 }

--- a/TransIT.DAL/Repositories/ImplementedRepositories/SupplierRepository.cs
+++ b/TransIT.DAL/Repositories/ImplementedRepositories/SupplierRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TransIT.DAL.Models;
 using TransIT.DAL.Models.Entities;
@@ -14,16 +15,34 @@ namespace TransIT.DAL.Repositories.ImplementedRepositories
                : base(context)
         {
         }
+ 
+        public override Task<IQueryable<Supplier>> SearchExpressionAsync(IEnumerable<string> strs)
+        {
+            var predicate = PredicateBuilder.New<Supplier>();
 
-        public override Task<IQueryable<Supplier>> SearchExpressionAsync(IEnumerable<string> strs) =>
-             Task.FromResult(
-                 GetQueryable().Where(entity =>
-                     strs.Any(str => !string.IsNullOrEmpty(entity.Name) && entity.Name.ToUpperInvariant().Contains(str)
-                     || !string.IsNullOrEmpty(entity.Edrpou) && entity.Edrpou.ToUpperInvariant().Contains(str)
-                     || !string.IsNullOrEmpty(entity.FullName) && entity.FullName.ToUpperInvariant().Contains(str)
-                     || !string.IsNullOrEmpty(entity.Country.Name) && entity.Country.Name.ToUpperInvariant().Contains(str)
-                     || !string.IsNullOrEmpty(entity.Currency.FullName) && entity.Currency.FullName.ToUpperInvariant().Contains(str)))
-                 );
+            foreach (string keyword in strs)
+            {
+                string temp = keyword;
+                predicate = predicate.And(entity =>
+                       entity.Name != null && entity.Name != string.Empty &&
+                           EF.Functions.Like(entity.Name, '%' + temp + '%')
+                    || entity.Edrpou != null && entity.Edrpou != string.Empty &&
+                           EF.Functions.Like(entity.Edrpou, '%' + temp + '%')
+                    || entity.FullName != null && entity.FullName != string.Empty &&
+                           EF.Functions.Like(entity.FullName, '%' + temp + '%')
+                    || entity.Country.Name != null && entity.Country.Name != string.Empty &&
+                           EF.Functions.Like(entity.Country.Name, '%' + temp + '%')
+                    || entity.Currency.FullName != null && entity.Currency.FullName != string.Empty &&
+                           EF.Functions.Like(entity.Currency.FullName, '%' + temp + '%')
+                    );
+            }
+
+            return Task.FromResult(
+                GetQueryable()
+                .AsExpandable()
+                .Where(predicate)
+            );
+        }
 
         protected override IQueryable<Supplier> ComplexEntities => Entities
                    .Include(t => t.Create)

--- a/TransIT.DAL/TransIT.DAL.csproj
+++ b/TransIT.DAL/TransIT.DAL.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="8.2.2" />
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="1.1.16" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.3" />
@@ -20,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Migrations\" />
     <Folder Include="UnitOfWork\" />
   </ItemGroup>
 


### PR DESCRIPTION
- rewrote SearchAsync method in all repositories, so now filtering happens in SQL WHERE statement
![Screenshot_2](https://user-images.githubusercontent.com/26359203/62473069-b45ea100-b7a8-11e9-9191-b3e0567500d5.png)
- search now matches ALL words in query instead of ANY word.
![Screenshot_4](https://user-images.githubusercontent.com/26359203/62473304-21723680-b7a9-11e9-9d77-469e7d2b15e6.png)
- return Internal server error when exception happens.